### PR TITLE
Show response text instead of trying to parse JSON

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -67,8 +67,8 @@ const parseAndSendEvents = async (events: PluginEventExtra[], { config, global }
             headers: { 'Content-Type': 'application/json' },
         })
         if (global.debug) {
-            const jsonRes = await res.json()
-            console.log('RESPONSE:', jsonRes)
+            const textRes = await res.text()
+            console.log('RESPONSE:', textRes)
         }
         console.log(`Flushing ${batch.length} event${batch.length > 1 ? 's' : ''} to ${config.host}`)
     } else if (global.debug) {


### PR DESCRIPTION
## Changes

If you're hitting the wrong endpoint you won't get JSON back and this console.log won't be very useful

## Checklist

-   [ ] Tests for new code
